### PR TITLE
Add CI functions

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,0 +1,53 @@
+name: Upload Python Package to PyPi and Artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+
+  build_linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies for building
+      run: pip install -r requirements.txt pyinstaller
+    - name: Create executable
+      run: pyinstaller your-code.py
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }} package
+        path: dist/*

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies for building
       run: pip install -r requirements.txt pyinstaller
     - name: Create executable
-      run: pyinstaller unfollow
+      run: pyinstaller unfollow --onefile
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }} package

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies for building
       run: pip install -r requirements.txt pyinstaller
     - name: Create executable
-      run: pyinstaller your-code.py
+      run: pyinstaller unfollow
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }} package

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
-  build_linux:
+  build_executable:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py')


### PR DESCRIPTION
# Description
Creates CI functions as per #10
- Adds pylint (failing right now - see below)
- Adds deploy to pypi action (manual deploy - needs to have a secret stored in the repo with the key)
- Adds build to artifacts (the exectutables don't work right now due to #9)
# Type of change

> Please delete options that are not relevant. For the item that is relevant mark it completed as `- [x] text here`

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
> E.g. - manually running the program on the localhost

Running GH actions in my fork, running executables (tested only linux version). Note again that #9 prevents the executables from running, but should work once fixed

# Checklist:

> Mark as completed `- [x] text here`

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

    While it's true that pylint generates new warnings, this could be addresed by another hacktoberfest issue, so that more people can help this project :)


Closes #10